### PR TITLE
OnePlus8 JPG with unreadable GPS data

### DIFF
--- a/jpg/metadata/diff/OnePlus8.jpg.txt
+++ b/jpg/metadata/diff/OnePlus8.jpg.txt
@@ -1,0 +1,121 @@
+       FILE: OnePlus8.jpg
+       TYPE: JPEG
+       
+       [JPEG - 0xfffffffd] Compression Type = Baseline
+       [JPEG - 0x0000] Data Precision = 8 bits
+       [JPEG - 0x0001] Image Height = 3000 pixels
+       [JPEG - 0x0003] Image Width = 4000 pixels
+       [JPEG - 0x0005] Number of Components = 3
+       [JPEG - 0x0006] Component 1 = Y component: Quantization table 0, Sampling factors 2 horiz/2 vert
+       [JPEG - 0x0007] Component 2 = Cb component: Quantization table 1, Sampling factors 1 horiz/1 vert
+       [JPEG - 0x0008] Component 3 = Cr component: Quantization table 1, Sampling factors 1 horiz/1 vert
+       
+       [Exif IFD0 - 0x0101] Image Height = 3000 pixels
+       [Exif IFD0 - 0x010f] Make = OnePlus
+       [Exif IFD0 - 0x0112] Orientation = Top, left side (Horizontal / normal)
+       [Exif IFD0 - 0x0132] Date/Time = 2020:08:25 09:30:43
+       [Exif IFD0 - 0x011b] Y Resolution = 72 dots per inch
+       [Exif IFD0 - 0x011a] X Resolution = 72 dots per inch
+       [Exif IFD0 - 0x0100] Image Width = 4000 pixels
+       [Exif IFD0 - 0x0110] Model = IN2023
+       [Exif IFD0 - 0x0213] YCbCr Positioning = Center of pixel array
+       [Exif IFD0 - 0x0128] Resolution Unit = Inch
+       
+       [GPS - 0x0002] GPS Latitude = 0° 0' 0"
+       [GPS - 0x0006] GPS Altitude = 0 metres
+       [GPS - 0x0001] GPS Latitude Ref = 
+       [GPS - 0x0005] GPS Altitude Ref = Sea level
+       [GPS - 0x001b] GPS Processing Method = 
+       [GPS - 0x0003] GPS Longitude Ref = 
+       [GPS - 0x0007] GPS Time-Stamp = 00:00:00.000 UTC
+       [GPS - 0x0004] GPS Longitude = 0° 0' 0"
+       [GPS - 0x001d] GPS Date Stamp = 
+       
+       [XMP - 0xffff] XMP Value Count = 7
+       
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:CaptureMode = Photo
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsBokehActive = False
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsHDRActive = False
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsNightModeActive = False
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:LensFacing = Back
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultConfidences = [0.7879277, 0.0, 0.0]
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultIds = [901, 0, 0]
+       
+       [Exif SubIFD - 0x9000] Exif Version = 2.20
+       [Exif SubIFD - 0x9202] Aperture Value = f/2.2
+       [Exif SubIFD - 0xa301] Scene Type = Unknown (0)
+       [Exif SubIFD - 0x9204] Exposure Bias Value = 0 EV
+       [Exif SubIFD - 0x8822] Exposure Program = Unknown (0)
+       [Exif SubIFD - 0xa001] Color Space = sRGB
+       [Exif SubIFD - 0x9205] Max Aperture Value = f/2.2
+       [Exif SubIFD - 0xa003] Exif Image Height = 3000 pixels
+       [Exif SubIFD - 0x9203] Brightness Value = 0.0
+       [Exif SubIFD - 0x9003] Date/Time Original = 2020:08:25 09:30:43
+       [Exif SubIFD - 0xa000] FlashPix Version = 1.00
+       [Exif SubIFD - 0x9291] Sub-Sec Time Original = 000343
+       [Exif SubIFD - 0xa403] White Balance Mode = Auto white balance
+       [Exif SubIFD - 0xa402] Exposure Mode = Auto exposure
+       [Exif SubIFD - 0x829a] Exposure Time = 1/2635 sec
+       [Exif SubIFD - 0x9209] Flash = Flash did not fire
+       [Exif SubIFD - 0x9290] Sub-Sec Time = 000343
+       [Exif SubIFD - 0x829d] F-Number = f/2.2
+       [Exif SubIFD - 0x8827] ISO Speed Ratings = 125
+       [Exif SubIFD - 0xa002] Exif Image Width = 4000 pixels
+       [Exif SubIFD - 0x9101] Components Configuration = YCbCr
+       [Exif SubIFD - 0xa405] Focal Length 35 = Unknown
+       [Exif SubIFD - 0x9292] Sub-Sec Time Digitized = 000343
+       [Exif SubIFD - 0x9004] Date/Time Digitized = 2020:08:25 09:30:43
+       [Exif SubIFD - 0x9201] Shutter Speed Value = 1/2633 sec
+       [Exif SubIFD - 0x9207] Metering Mode = Center weighted average
+JAVA   [Exif SubIFD - 0x920a] Focal Length = 3 mm
+DOTNET [Exif SubIFD - 0x920a] Focal Length = 3.1 mm
+       [Exif SubIFD - 0xa406] Scene Capture Type = Standard
+       [Exif SubIFD - 0x9208] White Balance = D65
+       [Exif SubIFD - 0xa217] Sensing Method = Unknown (0)
+       
+       [Interoperability - 0x0001] Interoperability Index = Recommended Exif Interoperability Rules (ExifR98)
+       
+       [Exif Thumbnail - 0x011b] Y Resolution = 72 dots per inch
+       [Exif Thumbnail - 0x0103] Compression = JPEG (old-style)
+       [Exif Thumbnail - 0x0201] Thumbnail Offset = 1635 bytes
+       [Exif Thumbnail - 0x0202] Thumbnail Length = 40833 bytes
+       [Exif Thumbnail - 0x011a] X Resolution = 72 dots per inch
+       [Exif Thumbnail - 0x0112] Orientation = Top, left side (Horizontal / normal)
+       [Exif Thumbnail - 0x0128] Resolution Unit = Inch
+       
+       [XMP - 0xffff] XMP Value Count = 7
+       
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:CaptureMode = Photo
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsBokehActive = False
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsHDRActive = False
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsNightModeActive = False
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:LensFacing = Back
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultConfidences = [0.7879277, 0.0, 0.0]
+       [XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultIds = [901, 0, 0]
+       
+       [Huffman - 0x0001] Number of Tables = 4 Huffman tables
+       
+       [File Type - 0x0001] Detected File Type Name = JPEG
+       [File Type - 0x0002] Detected File Type Long Name = Joint Photographic Experts Group
+       [File Type - 0x0003] Detected MIME Type = image/jpeg
+       [File Type - 0x0004] Expected File Name Extension = jpg
+       
+       [File - 0x0001] File Name = OnePlus8.jpg
+       [File - 0x0002] File Size = 5528597 bytes
+       [File - 0x0003] File Modified Date = <omitted for regression testing as checkout dependent>
+       
+       - JPEG
+       - Exif IFD0
+           - GPS
+           - XMP
+           - Exif SubIFD
+               - Interoperability
+           - Exif Thumbnail
+       - XMP
+       - Huffman
+       - File Type
+       - File
+       
+       Generated using metadata-extractor
+       https://drewnoakes.com/code/exif/
+       

--- a/jpg/metadata/dotnet/OnePlus8.jpg.txt
+++ b/jpg/metadata/dotnet/OnePlus8.jpg.txt
@@ -1,0 +1,119 @@
+FILE: OnePlus8.jpg
+TYPE: JPEG
+
+[JPEG - 0xfffffffd] Compression Type = Baseline
+[JPEG - 0x0000] Data Precision = 8 bits
+[JPEG - 0x0001] Image Height = 3000 pixels
+[JPEG - 0x0003] Image Width = 4000 pixels
+[JPEG - 0x0005] Number of Components = 3
+[JPEG - 0x0006] Component 1 = Y component: Quantization table 0, Sampling factors 2 horiz/2 vert
+[JPEG - 0x0007] Component 2 = Cb component: Quantization table 1, Sampling factors 1 horiz/1 vert
+[JPEG - 0x0008] Component 3 = Cr component: Quantization table 1, Sampling factors 1 horiz/1 vert
+
+[Exif IFD0 - 0x0101] Image Height = 3000 pixels
+[Exif IFD0 - 0x010f] Make = OnePlus
+[Exif IFD0 - 0x0112] Orientation = Top, left side (Horizontal / normal)
+[Exif IFD0 - 0x0132] Date/Time = 2020:08:25 09:30:43
+[Exif IFD0 - 0x011b] Y Resolution = 72 dots per inch
+[Exif IFD0 - 0x011a] X Resolution = 72 dots per inch
+[Exif IFD0 - 0x0100] Image Width = 4000 pixels
+[Exif IFD0 - 0x0110] Model = IN2023
+[Exif IFD0 - 0x0213] YCbCr Positioning = Center of pixel array
+[Exif IFD0 - 0x0128] Resolution Unit = Inch
+
+[GPS - 0x0002] GPS Latitude = 0° 0' 0"
+[GPS - 0x0006] GPS Altitude = 0 metres
+[GPS - 0x0001] GPS Latitude Ref = 
+[GPS - 0x0005] GPS Altitude Ref = Sea level
+[GPS - 0x001b] GPS Processing Method = 
+[GPS - 0x0003] GPS Longitude Ref = 
+[GPS - 0x0007] GPS Time-Stamp = 00:00:00.000 UTC
+[GPS - 0x0004] GPS Longitude = 0° 0' 0"
+[GPS - 0x001d] GPS Date Stamp = 
+
+[XMP - 0xffff] XMP Value Count = 7
+
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:CaptureMode = Photo
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsBokehActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsHDRActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsNightModeActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:LensFacing = Back
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultConfidences = [0.7879277, 0.0, 0.0]
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultIds = [901, 0, 0]
+
+[Exif SubIFD - 0x9000] Exif Version = 2.20
+[Exif SubIFD - 0x9202] Aperture Value = f/2.2
+[Exif SubIFD - 0xa301] Scene Type = Unknown (0)
+[Exif SubIFD - 0x9204] Exposure Bias Value = 0 EV
+[Exif SubIFD - 0x8822] Exposure Program = Unknown (0)
+[Exif SubIFD - 0xa001] Color Space = sRGB
+[Exif SubIFD - 0x9205] Max Aperture Value = f/2.2
+[Exif SubIFD - 0xa003] Exif Image Height = 3000 pixels
+[Exif SubIFD - 0x9203] Brightness Value = 0.0
+[Exif SubIFD - 0x9003] Date/Time Original = 2020:08:25 09:30:43
+[Exif SubIFD - 0xa000] FlashPix Version = 1.00
+[Exif SubIFD - 0x9291] Sub-Sec Time Original = 000343
+[Exif SubIFD - 0xa403] White Balance Mode = Auto white balance
+[Exif SubIFD - 0xa402] Exposure Mode = Auto exposure
+[Exif SubIFD - 0x829a] Exposure Time = 1/2635 sec
+[Exif SubIFD - 0x9209] Flash = Flash did not fire
+[Exif SubIFD - 0x9290] Sub-Sec Time = 000343
+[Exif SubIFD - 0x829d] F-Number = f/2.2
+[Exif SubIFD - 0x8827] ISO Speed Ratings = 125
+[Exif SubIFD - 0xa002] Exif Image Width = 4000 pixels
+[Exif SubIFD - 0x9101] Components Configuration = YCbCr
+[Exif SubIFD - 0xa405] Focal Length 35 = Unknown
+[Exif SubIFD - 0x9292] Sub-Sec Time Digitized = 000343
+[Exif SubIFD - 0x9004] Date/Time Digitized = 2020:08:25 09:30:43
+[Exif SubIFD - 0x9201] Shutter Speed Value = 1/2633 sec
+[Exif SubIFD - 0x9207] Metering Mode = Center weighted average
+[Exif SubIFD - 0x920a] Focal Length = 3.1 mm
+[Exif SubIFD - 0xa406] Scene Capture Type = Standard
+[Exif SubIFD - 0x9208] White Balance = D65
+[Exif SubIFD - 0xa217] Sensing Method = Unknown (0)
+
+[Interoperability - 0x0001] Interoperability Index = Recommended Exif Interoperability Rules (ExifR98)
+
+[Exif Thumbnail - 0x011b] Y Resolution = 72 dots per inch
+[Exif Thumbnail - 0x0103] Compression = JPEG (old-style)
+[Exif Thumbnail - 0x0201] Thumbnail Offset = 1635 bytes
+[Exif Thumbnail - 0x0202] Thumbnail Length = 40833 bytes
+[Exif Thumbnail - 0x011a] X Resolution = 72 dots per inch
+[Exif Thumbnail - 0x0112] Orientation = Top, left side (Horizontal / normal)
+[Exif Thumbnail - 0x0128] Resolution Unit = Inch
+
+[XMP - 0xffff] XMP Value Count = 7
+
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:CaptureMode = Photo
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsBokehActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsHDRActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsNightModeActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:LensFacing = Back
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultConfidences = [0.7879277, 0.0, 0.0]
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultIds = [901, 0, 0]
+
+[Huffman - 0x0001] Number of Tables = 4 Huffman tables
+
+[File Type - 0x0001] Detected File Type Name = JPEG
+[File Type - 0x0002] Detected File Type Long Name = Joint Photographic Experts Group
+[File Type - 0x0003] Detected MIME Type = image/jpeg
+[File Type - 0x0004] Expected File Name Extension = jpg
+
+[File - 0x0001] File Name = OnePlus8.jpg
+[File - 0x0002] File Size = 5528597 bytes
+[File - 0x0003] File Modified Date = <omitted for regression testing as checkout dependent>
+
+- JPEG
+- Exif IFD0
+    - GPS
+    - XMP
+    - Exif SubIFD
+        - Interoperability
+    - Exif Thumbnail
+- XMP
+- Huffman
+- File Type
+- File
+
+Generated using metadata-extractor
+https://drewnoakes.com/code/exif/

--- a/jpg/metadata/java/OnePlus8.jpg.txt
+++ b/jpg/metadata/java/OnePlus8.jpg.txt
@@ -1,0 +1,119 @@
+FILE: OnePlus8.jpg
+TYPE: JPEG
+
+[JPEG - 0xfffffffd] Compression Type = Baseline
+[JPEG - 0x0000] Data Precision = 8 bits
+[JPEG - 0x0001] Image Height = 3000 pixels
+[JPEG - 0x0003] Image Width = 4000 pixels
+[JPEG - 0x0005] Number of Components = 3
+[JPEG - 0x0006] Component 1 = Y component: Quantization table 0, Sampling factors 2 horiz/2 vert
+[JPEG - 0x0007] Component 2 = Cb component: Quantization table 1, Sampling factors 1 horiz/1 vert
+[JPEG - 0x0008] Component 3 = Cr component: Quantization table 1, Sampling factors 1 horiz/1 vert
+
+[Exif IFD0 - 0x0101] Image Height = 3000 pixels
+[Exif IFD0 - 0x010f] Make = OnePlus
+[Exif IFD0 - 0x0112] Orientation = Top, left side (Horizontal / normal)
+[Exif IFD0 - 0x0132] Date/Time = 2020:08:25 09:30:43
+[Exif IFD0 - 0x011b] Y Resolution = 72 dots per inch
+[Exif IFD0 - 0x011a] X Resolution = 72 dots per inch
+[Exif IFD0 - 0x0100] Image Width = 4000 pixels
+[Exif IFD0 - 0x0110] Model = IN2023
+[Exif IFD0 - 0x0213] YCbCr Positioning = Center of pixel array
+[Exif IFD0 - 0x0128] Resolution Unit = Inch
+
+[GPS - 0x0002] GPS Latitude = 0° 0' 0"
+[GPS - 0x0006] GPS Altitude = 0 metres
+[GPS - 0x0001] GPS Latitude Ref = 
+[GPS - 0x0005] GPS Altitude Ref = Sea level
+[GPS - 0x001b] GPS Processing Method = 
+[GPS - 0x0003] GPS Longitude Ref = 
+[GPS - 0x0007] GPS Time-Stamp = 00:00:00.000 UTC
+[GPS - 0x0004] GPS Longitude = 0° 0' 0"
+[GPS - 0x001d] GPS Date Stamp = 
+
+[XMP - 0xffff] XMP Value Count = 7
+
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:CaptureMode = Photo
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsBokehActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsHDRActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsNightModeActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:LensFacing = Back
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultConfidences = [0.7879277, 0.0, 0.0]
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultIds = [901, 0, 0]
+
+[Exif SubIFD - 0x9000] Exif Version = 2.20
+[Exif SubIFD - 0x9202] Aperture Value = f/2.2
+[Exif SubIFD - 0xa301] Scene Type = Unknown (0)
+[Exif SubIFD - 0x9204] Exposure Bias Value = 0 EV
+[Exif SubIFD - 0x8822] Exposure Program = Unknown (0)
+[Exif SubIFD - 0xa001] Color Space = sRGB
+[Exif SubIFD - 0x9205] Max Aperture Value = f/2.2
+[Exif SubIFD - 0xa003] Exif Image Height = 3000 pixels
+[Exif SubIFD - 0x9203] Brightness Value = 0.0
+[Exif SubIFD - 0x9003] Date/Time Original = 2020:08:25 09:30:43
+[Exif SubIFD - 0xa000] FlashPix Version = 1.00
+[Exif SubIFD - 0x9291] Sub-Sec Time Original = 000343
+[Exif SubIFD - 0xa403] White Balance Mode = Auto white balance
+[Exif SubIFD - 0xa402] Exposure Mode = Auto exposure
+[Exif SubIFD - 0x829a] Exposure Time = 1/2635 sec
+[Exif SubIFD - 0x9209] Flash = Flash did not fire
+[Exif SubIFD - 0x9290] Sub-Sec Time = 000343
+[Exif SubIFD - 0x829d] F-Number = f/2.2
+[Exif SubIFD - 0x8827] ISO Speed Ratings = 125
+[Exif SubIFD - 0xa002] Exif Image Width = 4000 pixels
+[Exif SubIFD - 0x9101] Components Configuration = YCbCr
+[Exif SubIFD - 0xa405] Focal Length 35 = Unknown
+[Exif SubIFD - 0x9292] Sub-Sec Time Digitized = 000343
+[Exif SubIFD - 0x9004] Date/Time Digitized = 2020:08:25 09:30:43
+[Exif SubIFD - 0x9201] Shutter Speed Value = 1/2633 sec
+[Exif SubIFD - 0x9207] Metering Mode = Center weighted average
+[Exif SubIFD - 0x920a] Focal Length = 3 mm
+[Exif SubIFD - 0xa406] Scene Capture Type = Standard
+[Exif SubIFD - 0x9208] White Balance = D65
+[Exif SubIFD - 0xa217] Sensing Method = Unknown (0)
+
+[Interoperability - 0x0001] Interoperability Index = Recommended Exif Interoperability Rules (ExifR98)
+
+[Exif Thumbnail - 0x011b] Y Resolution = 72 dots per inch
+[Exif Thumbnail - 0x0103] Compression = JPEG (old-style)
+[Exif Thumbnail - 0x0201] Thumbnail Offset = 1635 bytes
+[Exif Thumbnail - 0x0202] Thumbnail Length = 40833 bytes
+[Exif Thumbnail - 0x011a] X Resolution = 72 dots per inch
+[Exif Thumbnail - 0x0112] Orientation = Top, left side (Horizontal / normal)
+[Exif Thumbnail - 0x0128] Resolution Unit = Inch
+
+[XMP - 0xffff] XMP Value Count = 7
+
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:CaptureMode = Photo
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsBokehActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsHDRActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:IsNightModeActive = False
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:LensFacing = Back
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultConfidences = [0.7879277, 0.0, 0.0]
+[XMPMeta - http://ns.oneplus.com/media/1.0] OPMedia:SceneDetectResultIds = [901, 0, 0]
+
+[Huffman - 0x0001] Number of Tables = 4 Huffman tables
+
+[File Type - 0x0001] Detected File Type Name = JPEG
+[File Type - 0x0002] Detected File Type Long Name = Joint Photographic Experts Group
+[File Type - 0x0003] Detected MIME Type = image/jpeg
+[File Type - 0x0004] Expected File Name Extension = jpg
+
+[File - 0x0001] File Name = OnePlus8.jpg
+[File - 0x0002] File Size = 5528597 bytes
+[File - 0x0003] File Modified Date = <omitted for regression testing as checkout dependent>
+
+- JPEG
+- Exif IFD0
+    - GPS
+    - XMP
+    - Exif SubIFD
+        - Interoperability
+    - Exif Thumbnail
+- XMP
+- Huffman
+- File Type
+- File
+
+Generated using metadata-extractor
+https://drewnoakes.com/code/exif/


### PR DESCRIPTION
Even though the image gallery on this OnePlus 8 device shows an exact location for this image, metadata-extractor fails to read the info and reports zeroes for all GPS coordinates.

```
[GPS] - GPS Latitude = 0° 0' 0"
[GPS] - GPS Altitude = 0 metres
[GPS] - GPS Latitude Ref = 
[GPS] - GPS Altitude Ref = Sea level
[GPS] - GPS Processing Method = 
[GPS] - GPS Longitude Ref = 
[GPS] - GPS Time-Stamp = 00:00:00.000 UTC
[GPS] - GPS Longitude = 0° 0' 0"
[GPS] - GPS Date Stamp = 
```