### PR TITLE
Call Encoding.RegisterProvider when running on .NET 8, to ensure that…

### DIFF
--- a/src/dotnet/MetadataExtractor.MediaLibraryProcessor/Program.cs
+++ b/src/dotnet/MetadataExtractor.MediaLibraryProcessor/Program.cs
@@ -6,6 +6,10 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
+#if NET8_0_OR_GREATER
+System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+#endif
+
 // TODO support building libraries from source too
 
 // TODO more robust way of finding repo root path


### PR DESCRIPTION
… the Windows 1252 code page is available

When I was trying to test the NativeAOT situation described at https://github.com/drewnoakes/metadata-extractor-dotnet/issues/394 I got a number of differences in the results like this:

![image](https://github.com/drewnoakes/metadata-extractor-images/assets/1178570/37b0d49e-fea9-48dc-8d84-0d8f9ec48182)

Which I think is because .NET 8 doesn't have the Windows 1252 codepage registered by default, so the test app needs to call ```Encoding.RegisterProvider``` before running the tests to ensure that it's available if required?